### PR TITLE
Issue #3: Fix timeouts not being respected

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,13 @@ default = []
 [dependencies]
 curl = "0.4"
 http = "0.1"
+log = "0.4"
 ringtail = "0.1"
 
 [dependencies.json]
 version = "0.11"
 optional = true
+
+[dev-dependencies]
+env_logger = "0.5"
+rouille = "2.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@ extern crate curl;
 pub extern crate http;
 #[cfg(feature = "json")]
 extern crate json;
+#[macro_use]
+extern crate log;
 extern crate ringtail;
 
 pub mod body;

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1,6 +1,8 @@
 use ringtail::ByteBuffer;
 use curl;
+use curl::easy::InfoType;
 use http;
+use log;
 use std::cell::RefCell;
 use std::io;
 use std::io::Read;
@@ -94,8 +96,8 @@ impl Transport {
     pub fn execute(&mut self, request: Request) -> Result<http::response::Builder, Error> {
         self.begin_request(request)?;
 
-        // Wait for the headers to be read.
-        while !self.data.borrow().header_complete {
+        // Wait for the headers to be read, or for the request to be aborted.
+        while self.is_active() && !self.data.borrow().header_complete {
             self.dispatch()?;
         }
 
@@ -136,6 +138,9 @@ impl Transport {
                 })
             }
         };
+
+        // Enable or disable debug tracing.
+        easy.verbose(log_enabled!(log::Level::Trace))?;
 
         easy.max_connects(1)?;
         easy.signal(false)?;
@@ -232,21 +237,23 @@ impl Transport {
             let timeout = self.multi.get_timeout()?.unwrap_or(Duration::from_millis(DEFAULT_TIMEOUT_MS));
 
             // Block until activity is detected or the timeout passes.
+            trace!("waiting with timeout of {:?}", timeout);
             self.multi.wait(&mut [], timeout)?;
 
             // Perform any pending reads or writes. If `perform()` returns zero, then the current transfer is complete.
             if self.multi.perform()? == 0 {
-                self.end_request()?;
-
                 // The current transfer has stopped, but that does not mean it succeeded. Check the transfer status now
                 // and return any errors we find.
                 let mut result = None;
 
                 self.multi.messages(|message| {
+                    trace!("curl message: {:?}", message);
                     if let Some(Err(e)) = message.result() {
                         result = Some(e);
                     }
                 });
+
+                self.end_request()?;
 
                 if let Some(e) = result {
                     return Err(e.into());
@@ -345,5 +352,14 @@ impl curl::easy::Handler for Collector {
     // Gets called by curl when bytes from the response body are received.
     fn write(&mut self, data: &[u8]) -> Result<usize, curl::easy::WriteError> {
         Ok(self.data.borrow_mut().buffer.push(data))
+    }
+
+    fn debug(&mut self, kind: InfoType, data: &[u8]) {
+        match kind {
+            InfoType::Text => trace!(target: "curl", "{}", String::from_utf8_lossy(data).trim_right()),
+            InfoType::HeaderIn => trace!(target: "chttp::wire", "< {:?}", String::from_utf8_lossy(data)),
+            InfoType::HeaderOut => trace!(target: "chttp::wire", "> {:?}", String::from_utf8_lossy(data)),
+            _ => (),
+        }
     }
 }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -246,6 +246,7 @@ impl Transport {
                 // and return any errors we find.
                 let mut result = None;
 
+                // Read messages before we detach the easy handle, or the messages will be discarded.
                 self.multi.messages(|message| {
                     trace!("curl message: {:?}", message);
                     if let Some(Err(e)) = message.result() {

--- a/tests/timeouts.rs
+++ b/tests/timeouts.rs
@@ -4,8 +4,6 @@ extern crate rouille;
 
 use std::env;
 use std::time::Duration;
-use std::sync::Arc;
-use std::sync::atomic::*;
 use std::thread;
 
 /// Issue #3
@@ -14,9 +12,11 @@ fn request_errors_if_read_timeout_is_reached() {
     setup();
 
     // Spawn a slow server.
-    spawn_server(|_| {
-        thread::sleep(Duration::from_secs(3));
-        rouille::Response::text("hello world")
+    thread::spawn(|| {
+        rouille::start_server("localhost:18080", |_| {
+            thread::sleep(Duration::from_secs(3));
+            rouille::Response::text("hello world")
+        });
     });
 
     // Create an impatient client.
@@ -37,18 +37,4 @@ fn request_errors_if_read_timeout_is_reached() {
 fn setup() {
     env::set_var("RUST_LOG", "chttp=trace,curl=trace");
     env_logger::init();
-}
-
-fn spawn_server(handler: fn(&rouille::Request) -> rouille::Response) -> Arc<AtomicBool> {
-    let cancellation_token = Arc::new(AtomicBool::default());
-    let listen_token = cancellation_token.clone();
-    let server = rouille::Server::new("localhost:18080", handler).unwrap();
-
-    thread::spawn(move || {
-        while !listen_token.load(Ordering::SeqCst) {
-            server.poll();
-        }
-    });
-
-    cancellation_token
 }

--- a/tests/timeouts.rs
+++ b/tests/timeouts.rs
@@ -1,0 +1,54 @@
+extern crate chttp;
+extern crate env_logger;
+extern crate rouille;
+
+use std::env;
+use std::time::Duration;
+use std::sync::Arc;
+use std::sync::atomic::*;
+use std::thread;
+
+/// Issue #3
+#[test]
+fn request_errors_if_read_timeout_is_reached() {
+    setup();
+
+    // Spawn a slow server.
+    spawn_server(|_| {
+        thread::sleep(Duration::from_secs(3));
+        rouille::Response::text("hello world")
+    });
+
+    // Create an impatient client.
+    let mut options = chttp::Options::default();
+    options.timeout = Some(Duration::from_secs(2));
+    let client = chttp::Client::builder().options(options).build();
+
+    // Send a request.
+    let result = client.post("http://localhost:18080", "hello world");
+
+    // Client should time-out.
+    assert!(match result {
+        Err(chttp::Error::Timeout) => true,
+        _ => false,
+    });
+}
+
+fn setup() {
+    env::set_var("RUST_LOG", "chttp=trace,curl=trace");
+    env_logger::init();
+}
+
+fn spawn_server(handler: fn(&rouille::Request) -> rouille::Response) -> Arc<AtomicBool> {
+    let cancellation_token = Arc::new(AtomicBool::default());
+    let listen_token = cancellation_token.clone();
+    let server = rouille::Server::new("localhost:18080", handler).unwrap();
+
+    thread::spawn(move || {
+        while !listen_token.load(Ordering::SeqCst) {
+            server.poll();
+        }
+    });
+
+    cancellation_token
+}


### PR DESCRIPTION
Read pending error messages from libcurl for our multi handle _before_ detaching the easy handle, otherwise libcurl will discard the errors before we can read them. This was causing the request to spin forever in the case of a timeout, since libcurl finished handling the request, but we missed the notification of the status change.

Also add some helpful trace logging to debug these kinds of issues.