### PR TITLE
Add more configurable SSL options

### DIFF
--- a/src/internal/request.rs
+++ b/src/internal/request.rs
@@ -97,7 +97,9 @@ pub fn create<B: Into<Body>>(request: Request<B>, options: &Options) -> Result<(
     if let Some(key) = &options.ssl_private_key {
         easy.ssl_key(&key.path)?;
         easy.ssl_key_type(&key.format.to_string())?;
-        easy.key_password(&key.password)?;
+        if let Some(password) = &key.password {
+            easy.key_password(password)?;
+        }
     }
 
     // Set the request data according to the request given.

--- a/src/internal/request.rs
+++ b/src/internal/request.rs
@@ -86,6 +86,20 @@ pub fn create<B: Into<Body>>(request: Request<B>, options: &Options) -> Result<(
         easy.proxy(&format!("{}", proxy))?;
     }
 
+    // Configure SSL options.
+    if let Some(ciphers) = &options.ssl_ciphers {
+        easy.ssl_cipher_list(&ciphers.join(":"))?;
+    }
+    if let Some(cert) = &options.ssl_client_certificate {
+        easy.ssl_cert(&cert.path)?;
+        easy.ssl_cert_type(&cert.format.to_string())?;
+    }
+    if let Some(key) = &options.ssl_private_key {
+        easy.ssl_key(&key.path)?;
+        easy.ssl_key_type(&key.format.to_string())?;
+        easy.key_password(&key.password)?;
+    }
+
     // Set the request data according to the request given.
     easy.custom_request(request_parts.method.as_str())?;
     easy.url(&request_parts.uri.to_string())?;

--- a/src/internal/request.rs
+++ b/src/internal/request.rs
@@ -91,15 +91,7 @@ pub fn create<B: Into<Body>>(request: Request<B>, options: &Options) -> Result<(
         easy.ssl_cipher_list(&ciphers.join(":"))?;
     }
     if let Some(cert) = &options.ssl_client_certificate {
-        easy.ssl_cert(&cert.path)?;
-        easy.ssl_cert_type(&cert.format.to_string())?;
-    }
-    if let Some(key) = &options.ssl_private_key {
-        easy.ssl_key(&key.path)?;
-        easy.ssl_key_type(&key.format.to_string())?;
-        if let Some(password) = &key.password {
-            easy.key_password(password)?;
-        }
+        easy.ssl_client_certificate(cert)?;
     }
 
     // Set the request data according to the request given.
@@ -136,6 +128,66 @@ pub fn create<B: Into<Body>>(request: Request<B>, options: &Options) -> Result<(
     }).map(|response| response.map(Body::from_reader));
 
     Ok((CurlRequest(easy), future_rx))
+}
+
+/// Helper extension methods for curl easy handles.
+trait EasyExt {
+    fn easy(&mut self) -> &mut curl::easy::Easy2<CurlHandler>;
+
+    fn ssl_client_certificate(&mut self, cert: &ClientCertificate) -> Result<(), curl::Error> {
+        match cert {
+            ClientCertificate::PEM {path, private_key} => {
+                self.easy().ssl_cert(path)?;
+                self.easy().ssl_cert_type("PEM")?;
+                if let Some(key) = private_key {
+                    self.ssl_private_key(key)?;
+                }
+            },
+            ClientCertificate::DER {path, private_key} => {
+                self.easy().ssl_cert(path)?;
+                self.easy().ssl_cert_type("DER")?;
+                if let Some(key) = private_key {
+                    self.ssl_private_key(key)?;
+                }
+            },
+            ClientCertificate::P12 {path, password} => {
+                self.easy().ssl_cert(path)?;
+                self.easy().ssl_cert_type("P12")?;
+                if let Some(password) = password {
+                    self.easy().key_password(password)?;
+                }
+            },
+        }
+
+        Ok(())
+    }
+
+    fn ssl_private_key(&mut self, key: &PrivateKey) -> Result<(), curl::Error> {
+        match key {
+            PrivateKey::PEM {path, password} => {
+                self.easy().ssl_key(path)?;
+                self.easy().ssl_key_type("PEM")?;
+                if let Some(password) = password {
+                    self.easy().key_password(password)?;
+                }
+            },
+            PrivateKey::DER {path, password} => {
+                self.easy().ssl_key(path)?;
+                self.easy().ssl_key_type("DER")?;
+                if let Some(password) = password {
+                    self.easy().key_password(password)?;
+                }
+            },
+        }
+
+        Ok(())
+    }
+}
+
+impl EasyExt for curl::easy::Easy2<CurlHandler> {
+    fn easy(&mut self) -> &mut Self {
+        self
+    }
 }
 
 /// Encapsulates a curl request that can be executed by an agent.

--- a/src/options.rs
+++ b/src/options.rs
@@ -125,7 +125,7 @@ impl Default for Options {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum RedirectPolicy {
     /// Do not apply any special treatment to redirect responses. The response
-    /// will be return as-is and redirects will not be followed.
+    /// will be returned as-is and redirects will not be followed.
     ///
     /// This is the default policy.
     None,
@@ -190,20 +190,41 @@ impl Certificate {
 }
 
 /// A private key file.
+///
+/// If your private key file is encrypted with a password, use
+/// [`PrivateKey::with_password`] to set the password to use.
+///
+/// # Examples
+///
+/// ```
+/// # use chttp::options::*;
+/// let private_key = PrivateKey::new("key.pem", CertificateFormat::PEM)
+///     .with_password("secret");
+/// let options = Options::default()
+///     .with_ssl_private_key(Some(private_key));
+/// ```
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PrivateKey {
     pub(crate) path: PathBuf,
     pub(crate) format: CertificateFormat,
-    pub(crate) password: String,
+    pub(crate) password: Option<String>,
 }
 
 impl PrivateKey {
     /// Create a new private key object from the given path.
-    pub fn new(path: impl Into<PathBuf>, format: CertificateFormat, password: String) -> Self {
+    pub fn new(path: impl Into<PathBuf>, format: CertificateFormat) -> Self {
         Self {
             path: path.into(),
             format,
-            password,
+            password: None,
         }
+    }
+
+    /// Set the passphrase to private key.
+    ///
+    /// This will be used as the password required to decrypt the private key file.
+    pub fn with_password(mut self, password: impl Into<String>) -> Self {
+        self.password = Some(password.into());
+        self
     }
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,5 +1,6 @@
 //! Definition of all configurable client options.
 
+use std::path::PathBuf;
 use std::time::Duration;
 
 /// Defines various protocol and connection options.
@@ -10,10 +11,11 @@ pub struct Options {
     /// The default is to not follow redirects.
     pub redirect_policy: RedirectPolicy,
 
-    /// A preferred HTTP version the client should attempt to use to communicate to the server with.
+    /// A preferred HTTP version the client should attempt to use to communicate
+    /// to the server with.
     ///
-    /// This is treated as a suggestion. A different version may be used if the server does not support it or negotiates
-    /// a different version.
+    /// This is treated as a suggestion. A different version may be used if the
+    /// server does not support it or negotiates a different version.
     ///
     /// The default value is `None` (any version).
     pub preferred_http_version: Option<http::Version>,
@@ -67,6 +69,34 @@ pub struct Options {
     ///
     /// The default is unlimited.
     pub max_download_speed: Option<u64>,
+
+    /// A list of ciphers to use for SSL/TLS connections.
+    ///
+    /// The list of valid cipher names is dependent on the underlying SSL/TLS
+    /// engine in use.
+    ///
+    /// You can find an up-to-date list of potential cipher names at
+    /// <https://curl.haxx.se/docs/ssl-ciphers.html>.
+    ///
+    /// The default is unset and will result in the system defaults being used.
+    pub ssl_ciphers: Option<Vec<String>>,
+
+    /// A custom SSL/TLS client certificate to use for all client connections.
+    ///
+    /// When using a client certificate, you most likely also need to provide a
+    /// private key with `ssl_private_key`.
+    ///
+    /// The default value is none.
+    pub ssl_client_certificate: Option<Certificate>,
+
+    /// Private key corresponding to the custom SSL/TLS client certificate.
+    ///
+    /// This option is ignored if curl was built against Secure Transport on
+    /// macOS or iOS. Secure Transport expects the private key to be already
+    /// present in the keychain or PKCS#12 file containing the certificate.
+    ///
+    /// The default value is none.
+    pub ssl_private_key: Option<PrivateKey>,
 }
 
 impl Default for Options {
@@ -84,6 +114,9 @@ impl Default for Options {
             proxy: None,
             max_upload_speed: None,
             max_download_speed: None,
+            ssl_ciphers: None,
+            ssl_client_certificate: None,
+            ssl_private_key: None,
         }
     }
 }
@@ -91,8 +124,8 @@ impl Default for Options {
 /// Describes a policy for handling server redirects.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum RedirectPolicy {
-    /// Do not apply any special treatment to redirect responses. The response will be return as-is and redirects will
-    /// not be followed.
+    /// Do not apply any special treatment to redirect responses. The response
+    /// will be return as-is and redirects will not be followed.
     ///
     /// This is the default policy.
     None,
@@ -105,5 +138,72 @@ pub enum RedirectPolicy {
 impl Default for RedirectPolicy {
     fn default() -> Self {
         RedirectPolicy::None
+    }
+}
+
+/// Possible certificate archive file formats.
+///
+/// If a format is not supported by the underlying SSL/TLS engine, an error will
+/// be returned when attempting to send a request using the offending
+/// certificate.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CertificateFormat {
+    /// A DER-encoded certificate file.
+    DER,
+    /// A PEM-encoded certificate file.
+    PEM,
+    /// A PKCS#12-encoded certificate file.
+    P12,
+}
+
+impl Default for CertificateFormat {
+    fn default() -> Self {
+        CertificateFormat::PEM
+    }
+}
+
+impl std::fmt::Display for CertificateFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            CertificateFormat::DER => f.write_str("DER"),
+            CertificateFormat::PEM => f.write_str("PEM"),
+            CertificateFormat::P12 => f.write_str("P12"),
+        }
+    }
+}
+
+/// A public key certificate file.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Certificate {
+    pub(crate) path: PathBuf,
+    pub(crate) format: CertificateFormat,
+}
+
+impl Certificate {
+    /// Create a new certificate object from the given path.
+    pub fn new(path: impl Into<PathBuf>, format: CertificateFormat) -> Self {
+        Self {
+            path: path.into(),
+            format,
+        }
+    }
+}
+
+/// A private key file.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PrivateKey {
+    pub(crate) path: PathBuf,
+    pub(crate) format: CertificateFormat,
+    pub(crate) password: String,
+}
+
+impl PrivateKey {
+    /// Create a new private key object from the given path.
+    pub fn new(path: impl Into<PathBuf>, format: CertificateFormat, password: String) -> Self {
+        Self {
+            path: path.into(),
+            format,
+            password,
+        }
     }
 }


### PR DESCRIPTION
Provide request options for configuring a custom client certificate and private key for SSL/TLS connections.

Also expose the option for listing specific SSL/TLS cipher names to enable.

Resolves #19.