### PR TITLE
 fix: Ensure important code runs in release mode

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,6 +1,6 @@
 workflow "main" {
   on = "push"
-  resolves = ["test"]
+  resolves = ["test", "examples"]
 }
 
 workflow "release" {
@@ -13,8 +13,13 @@ action "test" {
   args = "cargo test"
 }
 
+action "examples" {
+  uses = "docker://rust"
+  args = "cargo run --release --example simple"
+}
+
 action "publish" {
-  needs = "test"
+  needs = ["test", "examples"]
   uses = "docker://rust"
   args = ".github/publish.sh"
   secrets = ["CARGO_TOKEN"]

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.vscode
 target
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ middleware-api = []
 
 [dependencies]
 bytes = "0.4"
-crossbeam-channel = "0.3"
+crossbeam = "0.7"
 curl = "^0.4.20"
 futures-preview = "0.2.2"
 http = "0.1"

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,7 +1,12 @@
+use std::env;
+
 fn main() -> Result<(), chttp::Error> {
+    env::set_var("RUST_BACKTRACE", "1");
+    env::set_var("RUST_LOG", "trace");
     env_logger::init();
 
-    let mut response = chttp::get("http://example.org")?;
+    let client = chttp::Client::new()?;
+    let mut response = client.get("http://example.org")?;
 
     println!("Status: {}", response.status());
     println!("Headers:\n{:?}", response.headers());


### PR DESCRIPTION
Previously, certain critical lines of code were accidentally wrapped in `debug_assert!` when `assert!` would have been appropriate. It seems that I misunderstood the implications of `debug_assert!`; the end result was that a critical piece of code, the code that resolves the request future, was put inside one such statement, resulting in it never being run in release mode.

This issue manifested itself in the internal future for a request never getting resolved before being closed, resulting in the caller getting a `Canceled` error.

- Add some code to ensure that dropping a `Client` is managed correctly.
- Run an example compiled in release mode during builds to ensure problems like these are caught before being merged.

Fixes #30.