### PR TITLE
Bump curl-sys to 0.4.20 to fix #34

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ middleware-api = []
 bytes = "0.4"
 crossbeam = "0.7"
 curl = "^0.4.20"
+curl-sys = "^0.4.20"
 futures-preview = "0.2.2"
 http = "0.1"
 lazy_static = "1"


### PR DESCRIPTION
Upgrades the bundled version of libcurl to 7.65.1.