### PR TITLE
Dependency tree trimming

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ static-curl = ["curl/static-curl"]
 middleware-api = []
 
 [dependencies]
-auto_enums = "0.5"
 bytes = "0.4"
 crossbeam-channel = "0.3"
 curl = "^0.4.20"
@@ -38,7 +37,6 @@ log = "0.4"
 regex = "1.1"
 slab = "0.4"
 sluice = "0.4.0-alpha.2"
-static_assertions = "0.3"
 
 [dependencies.chrono]
 version = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ futures-preview = "=0.3.0-alpha.17"
 http = "0.1"
 lazy_static = "1"
 log = "0.4"
-regex = "1.1"
 slab = "0.4"
 sluice = "0.4.0-alpha.2"
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -380,3 +380,19 @@ impl AgentThread {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn is_send<T: Send>() {}
+    fn is_sync<T: Sync>() {}
+
+    #[test]
+    fn traits() {
+        is_send::<Handle>();
+        is_sync::<Handle>();
+
+        is_send::<Message>();
+    }
+}

--- a/src/body.rs
+++ b/src/body.rs
@@ -212,4 +212,14 @@ impl fmt::Debug for Body {
     }
 }
 
-static_assertions::assert_impl!(body; Body, Send);
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn is_send<T: Send>() {}
+
+    #[test]
+    fn traits() {
+        is_send::<Body>();
+    }
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -286,14 +286,13 @@ impl Client {
     ///
     /// The response body is provided as a stream that may only be consumed
     /// once.
-    #[auto_enums::auto_enum(Future)]
     pub fn get_async<U>(&self, uri: U) -> impl Future<Output = Result<Response<Body>, Error>> + '_
     where
         http::Uri: http::HttpTryFrom<U>,
     {
         match http::Request::get(uri).body(Body::empty()) {
-            Ok(request) => self.send_async(request),
-            Err(e) => future::err(e.into()),
+            Ok(request) => self.send_async(request).left_future(),
+            Err(e) => future::err(e.into()).right_future(),
         }
     }
 
@@ -306,14 +305,13 @@ impl Client {
     }
 
     /// Sends an HTTP HEAD request asynchronously.
-    #[auto_enums::auto_enum(Future)]
     pub fn head_async<U>(&self, uri: U) -> impl Future<Output = Result<Response<Body>, Error>> + '_
     where
         http::Uri: http::HttpTryFrom<U>,
     {
         match http::Request::head(uri).body(Body::empty()) {
-            Ok(request) => self.send_async(request),
-            Err(e) => future::err(e.into()),
+            Ok(request) => self.send_async(request).left_future(),
+            Err(e) => future::err(e.into()).right_future(),
         }
     }
 
@@ -332,7 +330,6 @@ impl Client {
     ///
     /// The response body is provided as a stream that may only be consumed
     /// once.
-    #[auto_enums::auto_enum(Future)]
     pub fn post_async<U>(
         &self,
         uri: U,
@@ -342,8 +339,8 @@ impl Client {
         http::Uri: http::HttpTryFrom<U>,
     {
         match http::Request::post(uri).body(body) {
-            Ok(request) => self.send_async(request),
-            Err(e) => future::err(e.into()),
+            Ok(request) => self.send_async(request).left_future(),
+            Err(e) => future::err(e.into()).right_future(),
         }
     }
 
@@ -362,7 +359,6 @@ impl Client {
     ///
     /// The response body is provided as a stream that may only be consumed
     /// once.
-    #[auto_enums::auto_enum(Future)]
     pub fn put_async<U>(
         &self,
         uri: U,
@@ -372,8 +368,8 @@ impl Client {
         http::Uri: http::HttpTryFrom<U>,
     {
         match http::Request::put(uri).body(body) {
-            Ok(request) => self.send_async(request),
-            Err(e) => future::err(e.into()),
+            Ok(request) => self.send_async(request).left_future(),
+            Err(e) => future::err(e.into()).right_future(),
         }
     }
 
@@ -392,14 +388,13 @@ impl Client {
     ///
     /// The response body is provided as a stream that may only be consumed
     /// once.
-    #[auto_enums::auto_enum(Future)]
     pub fn delete_async<U>(&self, uri: U) -> impl Future<Output = Result<Response<Body>, Error>> + '_
     where
         http::Uri: http::HttpTryFrom<U>,
     {
         match http::Request::delete(uri).body(Body::empty()) {
-            Ok(request) => self.send_async(request),
-            Err(e) => future::err(e.into()),
+            Ok(request) => self.send_async(request).left_future(),
+            Err(e) => future::err(e.into()).right_future(),
         }
     }
 
@@ -688,5 +683,18 @@ impl Future for ResponseFuture<'_> {
     }
 }
 
-static_assertions::assert_impl!(client; Client, Send, Sync);
-static_assertions::assert_impl!(builder; ClientBuilder, Send);
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn is_send<T: Send>() {}
+    fn is_sync<T: Sync>() {}
+
+    #[test]
+    fn traits() {
+        is_send::<Client>();
+        is_sync::<Client>();
+
+        is_send::<ClientBuilder>();
+    }
+}

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -386,4 +386,14 @@ impl Drop for ResponseFuture {
     }
 }
 
-static_assertions::assert_impl!(f; ResponseFuture, Send);
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn is_send<T: Send>() {}
+
+    #[test]
+    fn traits() {
+        is_send::<ResponseFuture>();
+    }
+}

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,33 +1,122 @@
-use http::header::*;
+use http::header::{HeaderName, HeaderValue};
 use http::{StatusCode, Version};
-use lazy_static::lazy_static;
-use regex::bytes::Regex;
-
-lazy_static! {
-    static ref STATUS_LINE_REGEX: Regex = r#"^HTTP/(\d(?:\.\d)?) (\d{3})"#.parse().unwrap();
-    static ref HEADER_LINE_REGEX: Regex = r#"^([^:]+): *([^\r]*)\r\n$"#.parse().unwrap();
-}
 
 pub fn parse_status_line(line: &[u8]) -> Option<(Version, StatusCode)> {
-    STATUS_LINE_REGEX.captures(line).and_then(|captures| {
-        Some((
-            match &captures[1] {
-                b"HTTP/2" => Version::HTTP_2,
-                b"HTTP/1.1" => Version::HTTP_11,
-                b"HTTP/1.0" => Version::HTTP_10,
-                b"HTTP/0.9" => Version::HTTP_09,
-                _ => Version::default(),
-            },
-            StatusCode::from_bytes(&captures[2]).ok()?,
-        ))
-    })
+    let mut parts = line.split(u8::is_ascii_whitespace);
+
+    let version = match parts.next()? {
+        b"HTTP/2" => Version::HTTP_2,
+        b"HTTP/1.1" => Version::HTTP_11,
+        b"HTTP/1.0" => Version::HTTP_10,
+        b"HTTP/0.9" => Version::HTTP_09,
+        bytes => if bytes.starts_with(b"HTTP/") {
+            Version::default()
+        } else {
+            return None;
+        },
+    };
+
+    let status_code = parts.skip_while(|s| s.is_empty())
+        .next()
+        .map(StatusCode::from_bytes)?
+        .ok()?;
+
+    Some((version, status_code))
 }
 
 pub fn parse_header(line: &[u8]) -> Option<(HeaderName, HeaderValue)> {
-    HEADER_LINE_REGEX.captures(line).and_then(|captures| {
-        Some((
-            HeaderName::from_bytes(&captures[1]).ok()?,
-            HeaderValue::from_bytes(&captures[2]).ok()?,
-        ))
-    })
+    let mut parts = line.split(|byte| *byte == b':');
+
+    let name = parts.next()
+        .map(HeaderName::from_bytes)?
+        .ok()?;
+
+    let value = parts.next()
+        // Trim whitespace
+        .map(|mut part| {
+            while let Some((byte, right)) = part.split_first() {
+                if byte.is_ascii_whitespace() {
+                    part = right;
+                } else {
+                    break;
+                }
+            }
+
+            while let Some((byte, left)) = part.split_last() {
+                if byte.is_ascii_whitespace() {
+                    part = left;
+                } else {
+                    break;
+                }
+            }
+
+            part
+        })
+        .map(HeaderValue::from_bytes)?
+        .ok()?;
+
+    Some((name, value))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_valid_status_line() {
+        assert_eq!(parse_status_line(b"HTTP/0.9  200  \r\n"), Some((
+            Version::HTTP_09,
+            StatusCode::OK,
+        )));
+        assert_eq!(parse_status_line(b"HTTP/1.0 500 Internal Server Error\r\n"), Some((
+            Version::HTTP_10,
+            StatusCode::INTERNAL_SERVER_ERROR,
+        )));
+        assert_eq!(parse_status_line(b"HTTP/1.1 404 not found \r\n"), Some((
+            Version::HTTP_11,
+            StatusCode::NOT_FOUND,
+        )));
+        assert_eq!(parse_status_line(b"HTTP/2 200\r\n"), Some((
+            Version::HTTP_2,
+            StatusCode::OK,
+        )));
+    }
+
+    #[test]
+    fn parse_invalid_status_line() {
+        assert_eq!(parse_status_line(b""), None);
+        assert_eq!(parse_status_line(b" \r\n"), None);
+        assert_eq!(parse_status_line(b"HTP/foo bar baz\r\n"), None);
+        assert_eq!(parse_status_line(b"a-header: bar\r\n"), None);
+        assert_eq!(parse_status_line(b" HTTP/1.1 500 Internal Server Error\r\n"), None);
+    }
+
+    #[test]
+    fn parse_valid_headers() {
+        assert_eq!(parse_header(b"Empty:"), Some((
+            "empty".parse().unwrap(),
+            "".parse().unwrap(),
+        )));
+        assert_eq!(parse_header(b"CONTENT-LENGTH:20\r\n"), Some((
+            "content-length".parse().unwrap(),
+            "20".parse().unwrap(),
+        )));
+        assert_eq!(parse_header(b"x-Server:     Rust \r"), Some((
+            "x-server".parse().unwrap(),
+            "Rust".parse().unwrap(),
+        )));
+        assert_eq!(parse_header(b"X-val: Hello World\r"), Some((
+            "x-val".parse().unwrap(),
+            "Hello World".parse().unwrap(),
+        )));
+    }
+
+    #[test]
+    fn parse_invalid_headers() {
+        assert_eq!(parse_header(b""), None);
+        assert_eq!(parse_header(b":"), None);
+        assert_eq!(parse_header(b": bar"), None);
+        assert_eq!(parse_header(b"a\nheader: bar"), None);
+        assert_eq!(parse_header(b"foo : bar\r"), None);
+    }
 }


### PR DESCRIPTION
- **Remove auto_enums and static_assertions**: In response to issue #41, these two are dependencies that are hardly required and barely used, and both are heavy in the macro department and add lots of compile time.
- **Remove regex**: Regex is another big offender, which takes up a lot of binary space and also has a somewhat long compile time as well. Since we use it only to parse header lines, rewrite those parsers without regex and then remove the dependency.

This PR takes the total number of dependencies (without any features) from 61 to 46. According to `cargo bloat`, the biggest remaining dependency is the http crate (oddly enough), and removing that is not an option.