### PR TITLE
Rename Client to HttpClient and improve client docs

### DIFF
--- a/examples/parallel_requests.rs
+++ b/examples/parallel_requests.rs
@@ -3,7 +3,7 @@
 //! same thread, or from different threads as in this example.
 //!
 //! We're using Rayon here to make parallelism easy.
-use chttp::Client;
+use chttp::prelude::*;
 use rayon::prelude::*;
 use std::env;
 use std::time::Instant;
@@ -17,7 +17,7 @@ fn main() -> Result<(), chttp::Error> {
     let urls: Vec<String> = (0..count)
         .map(|i| format!("https://httpbin.org/anything/{:03}", i))
         .collect();
-    let client = Client::new();
+    let client = HttpClient::new();
 
     let start = Instant::now();
 

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,7 +1,7 @@
 use chttp::prelude::*;
 
 fn main() -> Result<(), chttp::Error> {
-    let client = chttp::Client::new();
+    let client = HttpClient::new();
     let mut response = client.get("http://example.org")?;
 
     println!("Status: {}", response.status());

--- a/src/client.rs
+++ b/src/client.rs
@@ -676,15 +676,10 @@ impl HttpClient {
         easy.accept_encoding("")?;
 
         // Set the request data according to the request given.
-        match parts.method {
-            http::Method::GET => easy.get(true)?,
-            http::Method::HEAD => {
-                easy.nobody(true)?;
-                easy.custom_request("HEAD")?;
-            }
-            http::Method::POST => easy.post(true)?,
-            http::Method::PUT => easy.put(true)?,
-            method => easy.custom_request(method.as_str())?,
+        easy.custom_request(parts.method.as_str())?;
+        // Curl handles HEAD requests differently.
+        if parts.method == http::Method::HEAD {
+            easy.nobody(true)?;
         }
 
         easy.url(&parts.uri.to_string())?;

--- a/src/client.rs
+++ b/src/client.rs
@@ -198,7 +198,6 @@ impl ClientBuilder {
     /// # use chttp::config::*;
     /// # use chttp::prelude::*;
     /// #
-    /// # fn run() -> Result<(), chttp::Error> {
     /// let client = Client::builder()
     ///     .ssl_client_certificate(ClientCertificate::PEM {
     ///         path: "client.pem".into(),
@@ -208,8 +207,7 @@ impl ClientBuilder {
     ///         }),
     ///     })
     ///     .build()?;
-    /// # Ok(())
-    /// # }
+    /// # Ok::<(), chttp::Error>(())
     /// ```
     pub fn ssl_client_certificate(mut self, certificate: ClientCertificate) -> Self {
         self.defaults.insert(certificate);
@@ -276,10 +274,12 @@ impl Client {
         ClientBuilder::default()
     }
 
-    /// Sends an HTTP GET request.
+    /// Send a GET request to the given URI.
     ///
     /// The response body is provided as a stream that may only be consumed
     /// once.
+    ///
+    /// See also [`Client::send_async`].
     pub fn get<U>(&self, uri: U) -> Result<Response<Body>, Error>
     where
         http::Uri: http::HttpTryFrom<U>,
@@ -287,10 +287,12 @@ impl Client {
         block_on(self.get_async(uri))
     }
 
-    /// Sends an HTTP GET request asynchronously.
+    /// Send a GET request to the given URI asynchronously.an HTTP
     ///
     /// The response body is provided as a stream that may only be consumed
     /// once.
+    ///
+    /// See also [`Client::send_async`].
     pub fn get_async<U>(&self, uri: U) -> ResponseFuture<'_>
     where
         http::Uri: http::HttpTryFrom<U>,
@@ -298,7 +300,9 @@ impl Client {
         self.send_builder_async(http::Request::get(uri), Body::empty())
     }
 
-    /// Sends an HTTP HEAD request.
+    /// Send a HEAD request to the given URI.
+    ///
+    /// See also [`Client::send_async`].
     pub fn head<U>(&self, uri: U) -> Result<Response<Body>, Error>
     where
         http::Uri: http::HttpTryFrom<U>,
@@ -306,7 +310,9 @@ impl Client {
         block_on(self.head_async(uri))
     }
 
-    /// Sends an HTTP HEAD request asynchronously.
+    /// Send a HEAD request to the given URI asynchronously.
+    ///
+    /// See also [`Client::send_async`].
     pub fn head_async<U>(&self, uri: U) -> ResponseFuture<'_>
     where
         http::Uri: http::HttpTryFrom<U>,
@@ -314,10 +320,23 @@ impl Client {
         self.send_builder_async(http::Request::head(uri), Body::empty())
     }
 
-    /// Sends an HTTP POST request.
+    /// Send a POST request to the given URI with a given request body.
     ///
     /// The response body is provided as a stream that may only be consumed
     /// once.
+    ///
+    /// See also [`Client::send_async`].
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// let client = chttp::Client::new();
+    ///
+    /// let response = client.post("https://httpbin.org/post", r#"{
+    ///     "speed": "fast",
+    ///     "cool_name": true
+    /// }"#)?;
+    /// # Ok::<(), chttp::Error>(())
     pub fn post<U>(&self, uri: U, body: impl Into<Body>) -> Result<Response<Body>, Error>
     where
         http::Uri: http::HttpTryFrom<U>,
@@ -325,10 +344,13 @@ impl Client {
         block_on(self.post_async(uri, body))
     }
 
-    /// Sends an HTTP POST request asynchronously.
+    /// Send a POST request to the given URI asynchronously with a given request
+    /// body.
     ///
     /// The response body is provided as a stream that may only be consumed
     /// once.
+    ///
+    /// See also [`Client::send_async`].
     pub fn post_async<U>(&self, uri: U, body: impl Into<Body>) -> ResponseFuture<'_>
     where
         http::Uri: http::HttpTryFrom<U>,
@@ -336,10 +358,25 @@ impl Client {
         self.send_builder_async(http::Request::post(uri), body)
     }
 
-    /// Sends an HTTP PUT request.
+    /// Send a PUT request to the given URI with a given request body.
     ///
     /// The response body is provided as a stream that may only be consumed
     /// once.
+    ///
+    /// To customize the request further, see [`Client::send`]. To send the
+    /// request asynchronously, see [`Client::put_async`].
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// let client = chttp::Client::new();
+    ///
+    /// let response = client.put("https://httpbin.org/put", r#"{
+    ///     "speed": "fast",
+    ///     "cool_name": true
+    /// }"#)?;
+    /// # Ok::<(), chttp::Error>(())
+    /// ```
     pub fn put<U>(&self, uri: U, body: impl Into<Body>) -> Result<Response<Body>, Error>
     where
         http::Uri: http::HttpTryFrom<U>,
@@ -347,10 +384,10 @@ impl Client {
         block_on(self.put_async(uri, body))
     }
 
-    /// Sends an HTTP PUT request asynchronously.
+    /// Send a PUT request to the given URI asynchronously with a given request
+    /// body.
     ///
-    /// The response body is provided as a stream that may only be consumed
-    /// once.
+    /// See [`Client::put`] for more details.
     pub fn put_async<U>(&self, uri: U, body: impl Into<Body>) -> ResponseFuture<'_>
     where
         http::Uri: http::HttpTryFrom<U>,
@@ -358,10 +395,12 @@ impl Client {
         self.send_builder_async(http::Request::put(uri), body)
     }
 
-    /// Sends an HTTP DELETE request.
+    /// Send a DELETE request to the given URI.
     ///
     /// The response body is provided as a stream that may only be consumed
     /// once.
+    ///
+    /// See also [`Client::send_async`].
     pub fn delete<U>(&self, uri: U) -> Result<Response<Body>, Error>
     where
         http::Uri: http::HttpTryFrom<U>,
@@ -369,10 +408,12 @@ impl Client {
         block_on(self.delete_async(uri))
     }
 
-    /// Sends an HTTP DELETE request asynchronously.
+    /// Send a DELETE request to the given URI asynchronously.
     ///
     /// The response body is provided as a stream that may only be consumed
     /// once.
+    ///
+    /// See also [`Client::send_async`].
     pub fn delete_async<U>(&self, uri: U) -> ResponseFuture<'_>
     where
         http::Uri: http::HttpTryFrom<U>,
@@ -380,28 +421,45 @@ impl Client {
         self.send_builder_async(http::Request::delete(uri), Body::empty())
     }
 
-    /// Sends a request and returns the response.
-    ///
-    /// The request may include [extensions](http::Extensions) to customize how
-    /// it is sent. If the request contains an [`Options`] struct as an
-    /// extension, then those options will be used instead of the default
-    /// options this client is configured with.
+    /// Send an HTTP request and return the HTTP response.
     ///
     /// The response body is provided as a stream that may only be consumed
     /// once.
+    ///
+    /// This client's configuration can be overridden for this request by
+    /// configuring the request using methods provided by the
+    /// [`RequestBuilderExt`](crate::prelude::RequestBuilderExt) trait.
+    ///
+    /// See also [`Client::send_async`].
     pub fn send<B: Into<Body>>(&self, request: Request<B>) -> Result<Response<Body>, Error> {
         block_on(self.send_async(request))
     }
 
-    /// Begin sending a request and return a future of the response.
-    ///
-    /// The request may include [extensions](http::Extensions) to customize how
-    /// it is sent. If the request contains an [`Options`] struct as an
-    /// extension, then those options will be used instead of the default
-    /// options this client is configured with.
+    /// Send an HTTP request and return the HTTP response asynchronously.
     ///
     /// The response body is provided as a stream that may only be consumed
     /// once.
+    ///
+    /// This client's configuration can be overridden for this request by
+    /// configuring the request using methods provided by the
+    /// [`RequestBuilderExt`](crate::prelude::RequestBuilderExt) trait.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// use chttp::prelude::*;
+    ///
+    /// # fn run() -> Result<(), chttp::Error> {
+    /// let response = Request::post("https://example.org")
+    ///     .header("Content-Type", "application/json")
+    ///     .body(r#"{
+    ///         "speed": "fast",
+    ///         "cool_name": true
+    ///     }"#)?
+    ///     .send()?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn send_async<B: Into<Body>>(&self, request: Request<B>) -> ResponseFuture<'_> {
         let mut request = request.map(Into::into);
 
@@ -632,6 +690,7 @@ impl EasyExt for curl::easy::Easy2<RequestHandler> {
     }
 }
 
+/// A future for a request being executed.
 #[derive(Debug)]
 pub struct ResponseFuture<'c> {
     /// The client this future is associated with.

--- a/src/client.rs
+++ b/src/client.rs
@@ -139,6 +139,9 @@ impl HttpClientBuilder {
     /// - **`socks4a`**: SOCKS4a Proxy. Proxy resolves URL hostname.
     /// - **`socks5`**: SOCKS5 Proxy.
     /// - **`socks5h`**: SOCKS5 Proxy. Proxy resolves URL hostname.
+    ///
+    /// By default no proxy will be used, unless one is specified in either the
+    /// `http_proxy` or `https_proxy` environment variables.
     pub fn proxy(mut self, proxy: http::Uri) -> Self {
         self.defaults.insert(Proxy(proxy));
         self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,8 +83,8 @@
 //! has its own connection pool and event loop, so separating certain requests
 //! into separate clients can ensure that they are isolated from each other.
 //!
-//! See the documentation for [`Client`] and [`ClientBuilder`] for more details
-//! on creating custom clients.
+//! See the documentation for [`HttpClient`] and [`HttpClientBuilder`] for more
+//! details on creating custom clients.
 //!
 //! ## Asynchronous API and execution
 //!
@@ -161,7 +161,7 @@ mod wakers;
 
 pub use crate::{
     body::Body,
-    client::{Client, ClientBuilder, ResponseFuture},
+    client::{HttpClient, HttpClientBuilder, ResponseFuture},
     error::Error,
 };
 
@@ -171,8 +171,8 @@ pub use http;
 /// A "prelude" for importing common cHTTP types.
 pub mod prelude {
     pub use crate::{
-        body::Body,
-        client::Client,
+        Body,
+        HttpClient,
         request::{RequestBuilderExt, RequestExt},
         response::ResponseExt,
     };
@@ -187,7 +187,7 @@ pub fn get<U>(uri: U) -> Result<Response<Body>, Error>
 where
     http::Uri: http::HttpTryFrom<U>,
 {
-    Client::shared().get(uri)
+    HttpClient::shared().get(uri)
 }
 
 /// Sends an HTTP GET request asynchronously.
@@ -197,7 +197,7 @@ pub fn get_async<U>(uri: U) -> ResponseFuture<'static>
 where
     http::Uri: http::HttpTryFrom<U>,
 {
-    Client::shared().get_async(uri)
+    HttpClient::shared().get_async(uri)
 }
 
 /// Sends an HTTP HEAD request.
@@ -205,7 +205,7 @@ pub fn head<U>(uri: U) -> Result<Response<Body>, Error>
 where
     http::Uri: http::HttpTryFrom<U>,
 {
-    Client::shared().head(uri)
+    HttpClient::shared().head(uri)
 }
 
 /// Sends an HTTP HEAD request asynchronously.
@@ -213,7 +213,7 @@ pub fn head_async<U>(uri: U) -> ResponseFuture<'static>
 where
     http::Uri: http::HttpTryFrom<U>,
 {
-    Client::shared().head_async(uri)
+    HttpClient::shared().head_async(uri)
 }
 
 /// Sends an HTTP POST request.
@@ -223,7 +223,7 @@ pub fn post<U>(uri: U, body: impl Into<Body>) -> Result<Response<Body>, Error>
 where
     http::Uri: http::HttpTryFrom<U>,
 {
-    Client::shared().post(uri, body)
+    HttpClient::shared().post(uri, body)
 }
 
 /// Sends an HTTP POST request asynchronously.
@@ -233,7 +233,7 @@ pub fn post_async<U>(uri: U, body: impl Into<Body>) -> ResponseFuture<'static>
 where
     http::Uri: http::HttpTryFrom<U>,
 {
-    Client::shared().post_async(uri, body)
+    HttpClient::shared().post_async(uri, body)
 }
 
 /// Sends an HTTP PUT request.
@@ -243,7 +243,7 @@ pub fn put<U>(uri: U, body: impl Into<Body>) -> Result<Response<Body>, Error>
 where
     http::Uri: http::HttpTryFrom<U>,
 {
-    Client::shared().put(uri, body)
+    HttpClient::shared().put(uri, body)
 }
 
 /// Sends an HTTP PUT request asynchronously.
@@ -253,7 +253,7 @@ pub fn put_async<U>(uri: U, body: impl Into<Body>) -> ResponseFuture<'static>
 where
     http::Uri: http::HttpTryFrom<U>,
 {
-    Client::shared().put_async(uri, body)
+    HttpClient::shared().put_async(uri, body)
 }
 
 /// Sends an HTTP DELETE request.
@@ -263,7 +263,7 @@ pub fn delete<U>(uri: U) -> Result<Response<Body>, Error>
 where
     http::Uri: http::HttpTryFrom<U>,
 {
-    Client::shared().delete(uri)
+    HttpClient::shared().delete(uri)
 }
 
 /// Sends an HTTP DELETE request asynchronously.
@@ -273,7 +273,7 @@ pub fn delete_async<U>(uri: U) -> ResponseFuture<'static>
 where
     http::Uri: http::HttpTryFrom<U>,
 {
-    Client::shared().delete_async(uri)
+    HttpClient::shared().delete_async(uri)
 }
 
 /// Sends an HTTP request.
@@ -284,15 +284,15 @@ where
 /// configuring the request using methods provided by the
 /// [`RequestBuilderExt`](crate::prelude::RequestBuilderExt) trait.
 pub fn send<B: Into<Body>>(request: Request<B>) -> Result<Response<Body>, Error> {
-    Client::shared().send(request)
+    HttpClient::shared().send(request)
 }
 
 /// Sends an HTTP request asynchronously.
 ///
-/// This function uses a globally allocated [Client] instance. See
-/// [`Client::send_async`] for more details and examples.
+/// This function uses a globally allocated [`HttpClient`] instance. See
+/// [`HttpClient::send_async`] for more details and examples.
 pub fn send_async<B: Into<Body>>(request: Request<B>) -> ResponseFuture<'static> {
-    Client::shared().send_async(request)
+    HttpClient::shared().send_async(request)
 }
 
 /// Gets a human-readable string with the version number of cHTTP and its

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,19 +169,25 @@ mod request;
 mod response;
 mod wakers;
 
-/// Re-export of the standard HTTP types.
-pub extern crate http;
+pub use crate::{
+    body::Body,
+    client::{Client, ClientBuilder, ResponseFuture},
+    error::Error,
+};
 
-pub use crate::body::Body;
-pub use crate::client::{Client, ClientBuilder, ResponseFuture};
-pub use crate::error::Error;
+/// Re-export of the standard HTTP types.
+pub use http;
 
 /// A "prelude" for importing common cHTTP types.
 pub mod prelude {
-    pub use crate::body::Body;
-    pub use crate::client::{Client, ClientBuilder};
-    pub use crate::request::{RequestBuilderExt, RequestExt};
-    pub use crate::response::ResponseExt;
+    pub use crate::{
+        body::Body,
+        client::{Client, ClientBuilder, ResponseFuture},
+        error::Error,
+        request::{RequestBuilderExt, RequestExt},
+        response::ResponseExt,
+    };
+
     pub use http::{Request, Response};
 }
 
@@ -283,23 +289,19 @@ where
 
 /// Sends an HTTP request.
 ///
-/// The request may include [extensions](http::Extensions) to
-/// customize how it is sent. You can include an
-/// [`Options`](crate::Options) struct as a request extension to
-/// control various connection and protocol options.
-///
 /// The response body is provided as a stream that may only be consumed once.
+///
+/// This client's configuration can be overridden for this request by
+/// configuring the request using methods provided by the
+/// [`RequestBuilderExt`](crate::prelude::RequestBuilderExt) trait.
 pub fn send<B: Into<Body>>(request: Request<B>) -> Result<Response<Body>, Error> {
     Client::shared().send(request)
 }
 
 /// Sends an HTTP request asynchronously.
 ///
-/// The request may include [extensions](http::Extensions) to customize how it
-/// is sent. You can include an [`Options`](crate::Options) struct as a request
-/// extension to control various connection and protocol options.
-///
-/// The response body is provided as a stream that may only be consumed once.
+/// This function uses a globally allocated [Client] instance. See
+/// [`Client::send_async`] for more details and examples.
 pub fn send_async<B: Into<Body>>(request: Request<B>) -> ResponseFuture<'static> {
     Client::shared().send_async(request)
 }
@@ -310,7 +312,7 @@ pub fn send_async<B: Into<Body>>(request: Request<B>) -> ResponseFuture<'static>
 /// This function can be helpful when troubleshooting issues in cHTTP or one of
 /// its dependencies.
 pub fn version() -> &'static str {
-    static FEATURES_STRING: &'static str = include_str!(concat!(env!("OUT_DIR"), "/features.txt"));
+    static FEATURES_STRING: &str = include_str!(concat!(env!("OUT_DIR"), "/features.txt"));
 
     lazy_static! {
         static ref VERSION_STRING: String = format!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,14 +5,12 @@
 //! Sending requests is as easy as calling a single function. Let's make a
 //! simple GET request to an example website:
 //!
-//! ```rust
+//! ```
 //! use chttp::prelude::*;
 //!
-//! # fn run() -> Result<(), chttp::Error> {
 //! let mut response = chttp::get("https://example.org")?;
 //! println!("{}", response.text()?);
-//! # Ok(())
-//! # }
+//! # Ok::<(), chttp::Error>(())
 //! ```
 //!
 //! By default, sending a request will wait for the response, up until the
@@ -22,22 +20,18 @@
 //! Sending a POST request is also easy, and takes an additional argument for
 //! the request body:
 //!
-//! ```rust
-//! # fn run() -> Result<(), chttp::Error> {
-//! let response = chttp::post("https://example.org", "make me a salad")?;
-//! # Ok(())
-//! # }
+//! ```
+//! let response = chttp::post("https://httpbin.org/post", "make me a salad")?;
+//! # Ok::<(), chttp::Error>(())
 //! ```
 //!
 //! cHTTP provides several other simple functions for common HTTP request types:
 //!
-//! ```rust
-//! # fn run() -> Result<(), chttp::Error> {
-//! chttp::put("https://example.org", "have a salad")?;
-//! chttp::head("https://example.org")?;
-//! chttp::delete("https://example.org")?;
-//! # Ok(())
-//! # }
+//! ```
+//! chttp::put("https://httpbin.org/put", "have a salad")?;
+//! chttp::head("https://httpbin.org/get")?;
+//! chttp::delete("https://httpbin.org/delete")?;
+//! # Ok::<(), chttp::Error>(())
 //! ```
 //!
 //! ## Custom requests
@@ -45,19 +39,17 @@
 //! cHTTP is not limited to canned HTTP verbs; you can customize requests by
 //! creating your own `Request` object and then `send`ing that.
 //!
-//! ```rust
+//! ```
 //! use chttp::prelude::*;
 //!
-//! # fn run() -> Result<(), chttp::Error> {
-//! let response = Request::post("https://example.org")
+//! let response = Request::post("https://httpbin.org/post")
 //!     .header("Content-Type", "application/json")
 //!     .body(r#"{
 //!         "speed": "fast",
 //!         "cool_name": true
 //!     }"#)?
 //!     .send()?;
-//! # Ok(())
-//! # }
+//! # Ok::<(), chttp::Error>(())
 //! ```
 //!
 //! ## Request configuration
@@ -68,17 +60,15 @@
 //! methods provided by the [`RequestBuilderExt`](prelude::RequestBuilderExt)
 //! trait:
 //!
-//! ```rust
+//! ```
 //! use chttp::prelude::*;
 //! use std::time::Duration;
 //!
-//! # fn run() -> Result<(), chttp::Error> {
-//! let response = Request::get("https://example.org")
+//! let response = Request::get("https://httpbin.org/get")
 //!     .timeout(Duration::from_secs(5))
 //!     .body(())?
 //!     .send()?;
-//! # Ok(())
-//! # }
+//! # Ok::<(), chttp::Error>(())
 //! ```
 //!
 //! Configuration related to sending requests is stored inside the request
@@ -108,14 +98,14 @@
 //! an asynchronous variant that ends with `_async` in the name. Here is our
 //! first example rewritten to use async/await syntax (nightly only):
 //!
-//! ```rust
+//! ```
 //! # #![cfg_attr(feature = "nightly", feature(async_await))]
 //! # use chttp::prelude::*;
 //! #
 //! # #[cfg(feature = "nightly")]
 //! # fn run() -> Result<(), chttp::Error> {
 //! # futures::executor::block_on(async {
-//! let mut response = chttp::get_async("https://example.org").await?;
+//! let mut response = chttp::get_async("https://httpbin.org/get").await?;
 //! println!("{}", response.text_async().await?);
 //! # Ok(())
 //! # })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,8 +182,7 @@ pub use http;
 pub mod prelude {
     pub use crate::{
         body::Body,
-        client::{Client, ClientBuilder, ResponseFuture},
-        error::Error,
+        client::Client,
         request::{RequestBuilderExt, RequestExt},
         response::ResponseExt,
     };

--- a/src/wakers.rs
+++ b/src/wakers.rs
@@ -58,7 +58,7 @@ impl ArcWake for UdpWaker {
         // We don't actually care here if this succeeds. Maybe the agent is
         // busy, or tired, or just needs some alone time right now.
         if let Err(e) = arc_self.socket.send(&[1]) {
-            log::warn!("agent waker produced an error: {}", e);
+            log::debug!("agent waker produced an error: {}", e);
         }
     }
 }


### PR DESCRIPTION
- Rename `Client` to `HttpClient` and `ClientBuilder` to `HttpClientBuilder`. For usability it helps to include the client type in our prelude, but the name `Client` is just a little too generic to do that. Using the name `HttpClient` is much less ambiguous as to what kind of client is in question. It's also a very common type name for HTTP clients and adds to familiarity.
- Improve the documentation for `HttpClient` methods with some examples as well.