### PR TITLE
Implement synchronous API without block_on

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,9 @@ bytes = "0.4"
 crossbeam-channel = "0.3"
 curl = "^0.4.20"
 curl-sys = "^0.4.20"
-futures-preview = "=0.3.0-alpha.17"
+futures-executor-preview = "0.3.0-alpha.17"
+futures-io-preview = "0.3.0-alpha.17"
+futures-util-preview = "0.3.0-alpha.17"
 http = "0.1"
 lazy_static = "1"
 log = "0.4"
@@ -62,6 +64,7 @@ optional = true
 
 [dev-dependencies]
 env_logger = "0.6"
+futures-preview = "0.3.0-alpha.17"
 mockito = "0.19"
 rayon = "1"
 speculate = "0.1"

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -12,10 +12,11 @@ use crate::wakers::{UdpWaker, WakerExt};
 use crate::Error;
 use crossbeam_channel::{Receiver, Sender};
 use curl::multi::WaitFd;
-use futures::task::*;
+use futures_util::task::ArcWake;
 use slab::Slab;
 use std::net::UdpSocket;
 use std::sync::Arc;
+use std::task::Waker;
 use std::thread;
 use std::time::{Duration, Instant};
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -317,14 +317,7 @@ impl AgentThread {
                 Ok((token, result)) => {
                     let handle = self.requests.remove(token);
                     let mut handle = self.multi.remove2(handle)?;
-
-                    match result {
-                        Ok(()) => handle.get_mut().complete(),
-                        Err(e) => {
-                            log::debug!("curl error: {}", e);
-                            handle.get_mut().complete_with_error(e);
-                        }
-                    }
+                    handle.get_mut().on_result(result);
                 }
                 Err(crossbeam_channel::TryRecvError::Empty) => break,
                 Err(crossbeam_channel::TryRecvError::Disconnected) => panic!(),

--- a/src/body.rs
+++ b/src/body.rs
@@ -2,13 +2,14 @@
 
 use crate::io::Text;
 use bytes::Bytes;
-use futures::io::AsyncReadExt;
-use futures::prelude::*;
+use futures_executor::block_on;
+use futures_io::AsyncRead;
+use futures_util::io::AsyncReadExt;
 use std::fmt;
 use std::io::{self, Cursor, Read};
 use std::pin::Pin;
 use std::str;
-use std::task::*;
+use std::task::{Context, Poll};
 
 /// Contains the body of an HTTP request or response.
 ///
@@ -140,7 +141,7 @@ impl Body {
 
 impl Read for Body {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        futures::executor::block_on(AsyncReadExt::read(self, buf))
+        block_on(AsyncReadExt::read(self, buf))
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -5,10 +5,10 @@ use crate::config::*;
 use crate::handler::{RequestHandler, RequestHandlerFuture};
 use crate::middleware::Middleware;
 use crate::{Body, Error};
-use futures::prelude::*;
 use http::{Request, Response};
 use lazy_static::lazy_static;
 use std::fmt;
+use std::future::Future;
 use std::iter::FromIterator;
 use std::net::SocketAddr;
 use std::pin::Pin;
@@ -903,7 +903,7 @@ impl Future for ResponseFuture<'_> {
         self.maybe_initialize()?;
 
         if let Some(inner) = self.inner.as_mut() {
-            inner.poll_unpin(cx).map(|result| self.complete(result))
+            Pin::new(inner).poll(cx).map(|result| self.complete(result))
         } else {
             // Invalid state (called poll() after ready), just return pending...
             Poll::Pending

--- a/src/client.rs
+++ b/src/client.rs
@@ -5,7 +5,6 @@ use crate::config::*;
 use crate::handler::{RequestHandler, RequestHandlerFuture};
 use crate::middleware::Middleware;
 use crate::{Body, Error};
-use futures::executor::block_on;
 use futures::prelude::*;
 use http::{Request, Response};
 use lazy_static::lazy_static;
@@ -364,11 +363,12 @@ impl HttpClient {
     /// println!("{}", response.text()?);
     /// # Ok::<(), chttp::Error>(())
     /// ```
+    #[inline]
     pub fn get<U>(&self, uri: U) -> Result<Response<Body>, Error>
     where
         http::Uri: http::HttpTryFrom<U>,
     {
-        block_on(self.get_async(uri))
+        self.get_async(uri).join()
     }
 
     /// Send a GET request to the given URI asynchronously.
@@ -396,11 +396,12 @@ impl HttpClient {
     /// println!("Page size: {:?}", response.headers()["content-length"]);
     /// # Ok::<(), chttp::Error>(())
     /// ```
+    #[inline]
     pub fn head<U>(&self, uri: U) -> Result<Response<Body>, Error>
     where
         http::Uri: http::HttpTryFrom<U>,
     {
-        block_on(self.head_async(uri))
+        self.head_async(uri).join()
     }
 
     /// Send a HEAD request to the given URI asynchronously.
@@ -431,11 +432,12 @@ impl HttpClient {
     ///     "cool_name": true
     /// }"#)?;
     /// # Ok::<(), chttp::Error>(())
+    #[inline]
     pub fn post<U>(&self, uri: U, body: impl Into<Body>) -> Result<Response<Body>, Error>
     where
         http::Uri: http::HttpTryFrom<U>,
     {
-        block_on(self.post_async(uri, body))
+        self.post_async(uri, body).join()
     }
 
     /// Send a POST request to the given URI asynchronously with a given request
@@ -468,11 +470,12 @@ impl HttpClient {
     /// }"#)?;
     /// # Ok::<(), chttp::Error>(())
     /// ```
+    #[inline]
     pub fn put<U>(&self, uri: U, body: impl Into<Body>) -> Result<Response<Body>, Error>
     where
         http::Uri: http::HttpTryFrom<U>,
     {
-        block_on(self.put_async(uri, body))
+        self.put_async(uri, body).join()
     }
 
     /// Send a PUT request to the given URI asynchronously with a given request
@@ -491,11 +494,12 @@ impl HttpClient {
     ///
     /// To customize the request further, see [`HttpClient::send`]. To execute
     /// the request asynchronously, see [`HttpClient::delete_async`].
+    #[inline]
     pub fn delete<U>(&self, uri: U) -> Result<Response<Body>, Error>
     where
         http::Uri: http::HttpTryFrom<U>,
     {
-        block_on(self.delete_async(uri))
+        self.delete_async(uri).join()
     }
 
     /// Send a DELETE request to the given URI asynchronously.
@@ -553,8 +557,9 @@ impl HttpClient {
     /// assert!(response.status().is_success());
     /// # Ok::<(), chttp::Error>(())
     /// ```
+    #[inline]
     pub fn send<B: Into<Body>>(&self, request: Request<B>) -> Result<Response<Body>, Error> {
-        block_on(self.send_async(request))
+        self.send_async(request).join()
     }
 
     /// Send an HTTP request and return the HTTP response asynchronously.
@@ -845,13 +850,11 @@ pub struct ResponseFuture<'c> {
     inner: Option<RequestHandlerFuture>,
 }
 
-impl Future for ResponseFuture<'_> {
-    type Output = Result<Response<Body>, Error>;
-
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+impl<'c> ResponseFuture<'c> {
+    fn maybe_initialize(&mut self) -> Result<(), Error> {
         // If the future has a pre-filled error, return that.
         if let Some(e) = self.error.take() {
-            return Poll::Ready(Err(e));
+            return Err(e);
         }
 
         // Request has not been sent yet.
@@ -865,20 +868,42 @@ impl Future for ResponseFuture<'_> {
             self.inner = Some(future);
         }
 
-        if let Some(inner) = self.inner.as_mut() {
-            match inner.poll_unpin(cx) {
-                Poll::Ready(Ok(mut response)) => {
-                    // Apply response middleware, starting with the innermost
-                    // one.
-                    for middleware in self.client.middleware.iter() {
-                        response = middleware.filter_response(response);
-                    }
+        Ok(())
+    }
 
-                    Poll::Ready(Ok(response))
-                }
-
-                poll => poll,
+    fn complete(&self, output: <Self as Future>::Output) -> <Self as Future>::Output {
+        output.map(|mut response| {
+            // Apply response middleware, starting with the innermost
+            // one.
+            for middleware in self.client.middleware.iter() {
+                response = middleware.filter_response(response);
             }
+
+            response
+        })
+    }
+
+    /// Block the current thread until the request is completed or aborted. This
+    /// effectively turns the asynchronous request into a synchronous one.
+    fn join(mut self) -> Result<Response<Body>, Error> {
+        self.maybe_initialize()?;
+
+        if let Some(inner) = self.inner.take() {
+            self.complete(inner.join())
+        } else {
+            panic!("join called after poll");
+        }
+    }
+}
+
+impl Future for ResponseFuture<'_> {
+    type Output = Result<Response<Body>, Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.maybe_initialize()?;
+
+        if let Some(inner) = self.inner.as_mut() {
+            inner.poll_unpin(cx).map(|result| self.complete(result))
         } else {
             // Invalid state (called poll() after ready), just return pending...
             Poll::Pending

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,16 +1,17 @@
 use crate::{parse, Body, Error};
 use crossbeam_channel::{Receiver, Sender, TryRecvError};
 use curl::easy::{InfoType, ReadError, SeekResult, WriteError};
-use futures::prelude::*;
-use futures::task::AtomicWaker;
+use futures_io::{AsyncRead, AsyncWrite};
+use futures_util::task::AtomicWaker;
 use http::Response;
 use sluice::pipe;
 use std::ascii;
 use std::fmt;
+use std::future::Future;
 use std::io;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::task::*;
+use std::task::{Context, Poll, Waker};
 
 /// Manages the state of a single request/response life cycle.
 ///

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -97,7 +97,7 @@ impl RequestHandler {
         )
     }
 
-    /// Determine if the associated has been dropped.
+    /// Determine if the associated future has been dropped.
     fn is_disconnected(&self) -> bool {
         Arc::strong_count(&self.shared) == 1
     }

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,5 +1,6 @@
-use futures::future::FutureExt;
-use futures::io::{AsyncRead, AsyncReadExt};
+use futures_io::AsyncRead;
+use futures_util::future::FutureExt;
+use futures_util::io::{AsyncReadExt, ReadToEnd};
 use std::future::Future;
 use std::io::{Error, ErrorKind};
 use std::pin::Pin;
@@ -10,7 +11,7 @@ use std::task::{Context, Poll};
 pub struct Text<'r, R: Unpin> {
     #[allow(clippy::box_vec)]
     buffer: Option<Box<Vec<u8>>>,
-    inner: Option<futures::io::ReadToEnd<'r, R>>,
+    inner: Option<ReadToEnd<'r, R>>,
 }
 
 impl<'r, R: AsyncRead + Unpin> Text<'r, R> {

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,6 +1,6 @@
 use crate::io::Text;
 use crate::Error;
-use futures::io::AsyncRead;
+use futures_io::AsyncRead;
 use http::Response;
 use std::fs::File;
 use std::io::{self, Read, Write};

--- a/src/wakers.rs
+++ b/src/wakers.rs
@@ -1,9 +1,10 @@
 //! Task waker implementations.
 
 use crate::Error;
-use futures::task::*;
+use futures_util::task::ArcWake;
 use std::net::{SocketAddr, UdpSocket};
 use std::sync::Arc;
+use std::task::Waker;
 
 /// Create a waker from a closure.
 fn waker_fn(f: impl Fn() + Send + Sync + 'static) -> Waker {


### PR DESCRIPTION
Change the main synchronous APIs to use a different mechanism other than `block_on` to wait for completion by using a crossbeam channel instead of a futures oneshot channel.

This has a couple of advantages:

- We no longer need `futures_channel`, so we can remove it from our dependency tree.
- It is possible that blocking on a crossbeam's native `recv()` is more efficient than running a local executor to poll a response future.

Also trim down the futures crate to the pieces we actually use.