### PR TITLE
fix: use CURLOPT_POSTFIELDSIZE for POST body

### DIFF
--- a/tests/request_body.rs
+++ b/tests/request_body.rs
@@ -1,0 +1,75 @@
+use chttp::prelude::*;
+use chttp::Body;
+use mockito::{mock, server_url};
+
+speculate::speculate! {
+    before {
+        env_logger::try_init().ok();
+    }
+
+    test "request with body of known size" {
+        for method in &["GET", "HEAD", "POST", "PUT", "DELETE", "PATCH", "FOOBAR"] {
+            let body = "MyVariableOne=ValueOne&MyVariableTwo=ValueTwo";
+
+            let m = mock(method, "/")
+                .match_header("content-type", "application/x-www-form-urlencoded")
+                .match_body(body)
+                .create();
+
+            Request::builder()
+                .method(*method)
+                .uri(server_url())
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .body(body)
+                .unwrap()
+                .send()
+                .unwrap();
+
+            m.assert();
+        }
+    }
+
+    test "request with body of unknown size uses chunked encoding" {
+        for method in &["GET", "HEAD", "POST", "PUT", "DELETE", "PATCH", "FOOBAR"] {
+            let body = "foo";
+
+            let m = mock(method, "/")
+                .match_header("transfer-encoding", "chunked")
+                .match_body(body)
+                .create();
+
+            Request::builder()
+                .method(*method)
+                .uri(server_url())
+                // This header should be ignored
+                .header("transfer-encoding", "identity")
+                .body(Body::reader(body.as_bytes()))
+                .unwrap()
+                .send()
+                .unwrap();
+
+            m.assert();
+        }
+    }
+
+    test "Content-Length header takes precedence over body object's length" {
+        for method in &["GET", "HEAD", "POST", "PUT", "DELETE", "PATCH", "FOOBAR"] {
+            let m = mock(method, "/")
+                .match_header("content-length", "3")
+                .match_body("abc") // Truncated to 3 bytes
+                .create();
+
+            Request::builder()
+                .method(*method)
+                .uri(server_url())
+                // Override given body's length
+                .header("content-length", "3")
+                .body("abc123")
+                .unwrap()
+                .send()
+                .unwrap();
+
+            m.assert();
+        }
+    }
+}


### PR DESCRIPTION
When sending a POST request with a body, the body length must be specified using CURLOPT_POSTFIELDSIZE, not CURLOPT_INFILESIZE like for other request methods.

If the user provides a `Content-Length` header, use that as the request body size, even if the body itself has an unknown size.

In addition, for bodies with an unknown size, set `Transfer-Encoding: chunked` explicitly to ensure that curl knows to use chunked encoding.

Add more comprehensive tests for sending a request body to ensure that such bugs are caught in the future.

Fixes #51.